### PR TITLE
Tomography L1 reconstruction example: use dot product operator

### DIFF
--- a/examples/applications/plot_tomography_l1_reconstruction.py
+++ b/examples/applications/plot_tomography_l1_reconstruction.py
@@ -114,7 +114,7 @@ def generate_synthetic_data():
 l = 128
 proj_operator = build_projection_operator(l, l // 7)
 data = generate_synthetic_data()
-proj = proj_operator * data.ravel()[:, np.newaxis]
+proj = proj_operator @ data.ravel()[:, np.newaxis]
 proj += 0.15 * np.random.randn(*proj.shape)
 
 # Reconstruction with L2 (Ridge) penalization


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

None

#### What does this implement/fix? Explain your changes.

In the compressive sensing example, there is a line that looks like a **hadamard product**

```python
proj = proj_operator * data.ravel()[:, np.newaxis]
```

but, because `proj_operator` is a `scipy.sparse.coo.coo_matrix`, this line **is actually a dot product**. To make this clear and to improve readability, the operator was changed to `@`

```python
proj = proj_operator @ data.ravel()[:, np.newaxis]
```